### PR TITLE
Issue #13: Update button label to 'Code block'.

### DIFF
--- a/ckeditor5.module
+++ b/ckeditor5.module
@@ -373,7 +373,7 @@ function ckeditor5_ckeditor5_plugins() {
   $plugins['codeBlock.CodeBlock'] = array(
     'buttons' => array(
       'codeBlock' => array(
-        'label' => t('Code'),
+        'label' => t('Code block'),
         'image' => $image_prefix . '/code-block.svg',
         'required_html' => array('<code>', '<pre>'),
       ),


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ckeditor5/issues/13.