### PR TITLE
Issue #37: Fix content warning popping up on every edit.

### DIFF
--- a/js/ckeditor5.formatter.js
+++ b/js/ckeditor5.formatter.js
@@ -105,7 +105,7 @@
         }
 
         if (isClosingTag(line, elementsToFormat)) {
-          return indentLine(line, --indentCount);
+          return indentLine(line, --indentCount) + '\n';
         }
 
         return indentLine(line, indentCount);
@@ -125,7 +125,7 @@
         return false;
       }
 
-      if (!new RegExp(`<${ element.name }( .*?)?>`).test(line)) {
+      if (!new RegExp('<' + element.name  + '( .*?)?>').test(line)) {
         return false;
       }
 
@@ -141,7 +141,7 @@
    */
   function isClosingTag( line, elementsToFormat) {
     return elementsToFormat.some((element) => {
-      return new RegExp( `</${ element.name }>` ).test( line );
+      return new RegExp( '</' + element.name + '>').test(line);
     });
   }
 
@@ -154,7 +154,7 @@
    */
   function indentLine(line, indentCount, indentChar = '    ' ) {
     // More about Math.max() here in https://github.com/ckeditor/ckeditor5/issues/10698.
-    return `${ indentChar.repeat(Math.max(0, indentCount))}${ line }`;
+    return indentChar.repeat(Math.max(0, indentCount)) + line.trim();
   }
 
 })(Backdrop);

--- a/js/ckeditor5.js
+++ b/js/ckeditor5.js
@@ -86,7 +86,7 @@
 
     detach: function (element, format, trigger) {
       // Remove any content modification warning.
-      if (element.ckeditor5AttachedWarning) {
+      if (element.ckeditor5AttachedWarning && trigger !== 'serialize') {
         element.ckeditor5AttachedWarning.remove();
         delete element.ckeditor5AttachedWarning;
       }
@@ -97,18 +97,21 @@
         return false;
       }
 
-      if (trigger === 'serialize') {
-        // CKEditor 5 does not pretty-print HTML source. Format the source
-        // before saving it into the source field.
-        let newData = editor.getData();
-        newData = Backdrop.ckeditor5.formatHtml(newData);
-        editor.updateSourceElement(newData);
-      }
-      else {
+      // CKEditor 5 does not pretty-print HTML source. Format the source
+      // before saving it into the source field.
+      let newData = editor.getData();
+      newData = Backdrop.ckeditor5.formatHtml(newData);
+
+      // Destroy the instance if fully detaching.
+      if (trigger !== 'serialize') {
         editor.destroy();
         Backdrop.ckeditor5.instances.delete(editor.id);
         delete element.ckeditor5AttachedEditor;
       }
+
+      // Save formatted value after destroying the editor, which can also
+      // update the element value.
+      element.value = newData;
 
       // Restore the resize grippie.
       $(element).siblings('.grippie').show();
@@ -279,7 +282,6 @@
      *   Returns true if values have been modified, false if unchanged.
      */
     detachWithWarning: function (element, format, beforeAttachValues) {
-      const editor = element.ckeditor5AttachedEditor;
       // Detach the editor.
       Backdrop.filterEditorDetach(element, format);
       // Restore the value to what it was previously.


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ckeditor5/issues/37

Follow-up to fix a bug where the warning was showing up every time on edit. Also the formatted HTML wasn't saving consistently.