### PR TITLE
Issue #5: Load all CKEditor 5 plugin libraries when needed.

### DIFF
--- a/ckeditor5.module
+++ b/ckeditor5.module
@@ -85,13 +85,15 @@ function ckeditor5_library_info() {
       array('filter', 'filter'),
       array('system', 'backdrop.ajax'),
       array('ckeditor5', 'ckeditor5'),
-      // CKEditor 5 does not provide its own plugin loader, so any added
-      // potentially needed plugins are added as dependencies.
-      // @todo: Improve loading to use libraries only when needed.
-      array('ckeditor5', 'backdrop.ckeditor5.backdrop-basic-styles'),
-      array('ckeditor5', 'backdrop.ckeditor5.backdrop-image'),
-      array('ckeditor5', 'backdrop.ckeditor5.backdrop-link'),
     ),
+  );
+
+  // CKEditor 5 does not have a built-in script loader. Any needed dependencies
+  // should be present on the page when CKEditor loads. Add in library
+  // dependencies to the overall CKEditor 5 library.
+  $libraries['backdrop.ckeditor5']['dependencies'] = array_merge(
+    $libraries['backdrop.ckeditor5']['dependencies'],
+    _ckeditor5_get_plugin_libraries()
   );
 
   $libraries['backdrop.ckeditor5.backdrop-basic-styles'] = array(
@@ -179,10 +181,20 @@ function ckeditor5_js_alter(&$javascript) {
 
 /**
  * Retrieves the full list of installed CKEditor plugins.
+ *
+ * @return array
+ *   An array of CKEditor plugin information, as returned by
+ *   hook_ckeditor5_plugins().
+ *
+ * @see hook_ckeditor5_plugins()
+ * @see hook_ckeditor5_plugins_alter()
  */
 function ckeditor5_plugins() {
-  $plugins = module_invoke_all('ckeditor5_plugins');
-  backdrop_alter('ckeditor5_plugins', $plugins);
+  $plugins = &backdrop_static(__FUNCTION__, array());
+  if (!$plugins) {
+    $plugins = module_invoke_all('ckeditor5_plugins');
+    backdrop_alter('ckeditor5_plugins', $plugins);
+  }
   return $plugins;
 }
 
@@ -803,10 +815,16 @@ function _ckeditor5_link_image_plugin_check($format, $plugin_name) {
  *
  * @param object $format
  *   The filter format object for which CKEditor is adding its config.
- * @param array $existing_settings
- *   Settings that have already been added to the page by filters.
  */
-function ckeditor5_get_config($format, array $existing_settings) {
+function ckeditor5_get_config($format) {
+  // Static cache the configuration per format. This function is called once per
+  // filtered text field on the page.
+  $ckeditor5_configs = &backdrop_static(__FUNCTION__, array());
+  $format_id = $format->name;
+  if (isset($ckeditor5_configs[$format_id])) {
+    return $ckeditor5_configs[$format_id];
+  }
+
   global $language;
 
   // Loop through all available plugins and check to see if it has been
@@ -818,7 +836,6 @@ function ckeditor5_get_config($format, array $existing_settings) {
   $all_buttons = array();
   $plugins = array();
   $pseudo_plugins = array();
-  $libraries = array();
   foreach ($plugin_info as $plugin_name => $plugin) {
     // Check if this plugin should be enabled.
     if (isset($plugin['enabled_callback'])) {
@@ -826,10 +843,6 @@ function ckeditor5_get_config($format, array $existing_settings) {
         $plugins[] = $plugin_name;
         if (!empty($plugin['pseudo_plugin'])) {
           $pseudo_plugins[] = $plugin_name;
-        }
-        // Add the library from hook_library_info() for this plugin.
-        if (isset($plugin['library'])) {
-          $libraries[] = $plugin['library'];
         }
         // Enable other plugins this plugin depends on.
         if (isset($plugin['plugin_dependencies'])) {
@@ -917,7 +930,7 @@ function ckeditor5_get_config($format, array $existing_settings) {
   // settings from the Filter module. Prevents data loss for content not handled
   // by editor plugins.
   $config['htmlSupport'] = array();
-  list($config['htmlSupport']['allow'], $config['htmlSupport']['disallow']) = ckeditor5_get_generic_html_settings($format);
+  [$config['htmlSupport']['allow'], $config['htmlSupport']['disallow']] = _ckeditor5_get_generic_html_settings($format);
 
   // Create a token for access to dialogs.
   if (in_array('backdropLink.BackdropLink', $plugins)) {
@@ -1004,7 +1017,9 @@ function ckeditor5_get_config($format, array $existing_settings) {
 
   backdrop_alter('ckeditor5_config', $config, $format);
 
-  return $config;
+  // Save the configuration into the static variable.
+  $ckeditor5_configs[$format_id] = $config;
+  return $ckeditor5_configs[$format_id];
 }
 
 /**
@@ -1024,7 +1039,7 @@ function ckeditor5_get_config($format, array $existing_settings) {
  *   - Configuration array of disallowed content rules used by the editor's
  *     General HTML Support "disallow" setting.
  */
-function ckeditor5_get_generic_html_settings($format) {
+function _ckeditor5_get_generic_html_settings($format) {
   $html_restrictions = filter_format_allowed_html($format);
 
   // When all HTML is allowed, we return empty arrays. This case gets handled in
@@ -1201,6 +1216,24 @@ function ckeditor5_get_generic_html_settings($format) {
   $disallowed = array_values($disallowed);
 
   return array($allowed, $disallowed);
+}
+
+/**
+ * Retrieve a list of CKEditor-related libraries used by any CKEditor 5 plugin.
+ *
+ * @return array
+ *   An array of library keys.
+ */
+function _ckeditor5_get_plugin_libraries() {
+  $plugins = ckeditor5_plugins();
+  $libraries = array();
+  foreach ($plugins as $plugin) {
+    if (isset($plugin['library'])) {
+      $libraries[$plugin['library'][0] . '--' . $plugin['library'][1]] = $plugin['library'];
+    }
+  }
+
+  return array_values($libraries);
 }
 
 /**

--- a/ckeditor5.module
+++ b/ckeditor5.module
@@ -930,7 +930,7 @@ function ckeditor5_get_config($format) {
   // settings from the Filter module. Prevents data loss for content not handled
   // by editor plugins.
   $config['htmlSupport'] = array();
-  [$config['htmlSupport']['allow'], $config['htmlSupport']['disallow']] = _ckeditor5_get_generic_html_settings($format);
+  list($config['htmlSupport']['allow'], $config['htmlSupport']['disallow']) = _ckeditor5_get_generic_html_settings($format);
 
   // Create a token for access to dialogs.
   if (in_array('backdropLink.BackdropLink', $plugins)) {


### PR DESCRIPTION
Fixes #5.

Alternative to https://github.com/backdrop-contrib/ckeditor5/pull/82.

This differs in that it does not calculate if a CKEditor plugin library is used. If a module provides a CKEditor plugin, it's now loaded whenever a CKEditor instance is present. This is a simpler approach but may load unnecessary JS/CSS when a plugin is not needed.