### PR TITLE
Issue #68: Port DrupalHtmlEngine plugin for escaping HTML attributes (data-caption in particular).

### DIFF
--- a/ckeditor5.module
+++ b/ckeditor5.module
@@ -103,6 +103,13 @@ function ckeditor5_library_info() {
       $module_path . '/js/plugins/backdrop-basic-styles/backdrop-basic-styles.js' => array(),
     ),
   );
+  $libraries['backdrop.ckeditor5.backdrop-html-engine'] = array(
+    'title' => 'CKEditor plugin that writes the HTML source from the editor.',
+    'version' => $info['version'],
+    'js' => array(
+      $module_path . '/js/plugins/backdrop-html-engine/backdrop-html-engine.js' => array(),
+    ),
+  );
   $libraries['backdrop.ckeditor5.backdrop-image'] = array(
     'title' => 'Integrates uploading images with CKEditor 5.',
     'version' => $info['version'],
@@ -515,6 +522,13 @@ function ckeditor5_ckeditor5_plugins() {
   // such as converting <s> to <del> or <i> to <em>.
   $plugins['backdropBasicStyles.BackdropBasicStyles'] = array(
     'library' => array('ckeditor5', 'backdrop.ckeditor5.backdrop-basic-styles'),
+    'enabled_callback' => TRUE,
+  );
+
+  // Plugin that writes the HTML source when saving the editor contents. This
+  // properly escapes HTML attributes and formats the HTML source.
+  $plugins['backdropHtmlEngine.BackdropHtmlEngine'] = array(
+    'library' => array('ckeditor5', 'backdrop.ckeditor5.backdrop-html-engine'),
     'enabled_callback' => TRUE,
   );
 

--- a/ckeditor5.module
+++ b/ckeditor5.module
@@ -507,6 +507,12 @@ function ckeditor5_ckeditor5_plugins() {
     ),
   );
 
+  // General HTML support is always enabled in Backdrop to provide compatibility
+  // with existing content and to preserve otherwise unsupported HTML tags.
+  $plugins['htmlSupport.GeneralHtmlSupport'] = array(
+    'enabled_callback' => TRUE,
+  );
+
   // @see https://ckeditor.com/docs/ckeditor5/latest/features/special-characters.html
   $plugins['specialCharacters.SpecialCharacters'] = array(
     'buttons' => array(
@@ -912,11 +918,6 @@ function ckeditor5_get_config($format) {
 
   // Remove duplicates from the plugin list (as happens with dependencies).
   $plugins = array_unique($plugins);
-
-  // We always load the GeneralHtmlSupport plugin.
-  if (!in_array('htmlSupport.GeneralHtmlSupport', $plugins)) {
-    $plugins[] = 'htmlSupport.GeneralHtmlSupport';
-  }
 
   // Initialize reasonable defaults that provide expected basic behavior.
   $config = array(

--- a/js/plugins/backdrop-basic-styles/backdrop-basic-styles.js
+++ b/js/plugins/backdrop-basic-styles/backdrop-basic-styles.js
@@ -1,5 +1,7 @@
 (function (CKEditor5) {
 
+"use strict";
+
 /**
  * Backdrop-specific plugin to alter the CKEditor 5 basic tags.
  */

--- a/js/plugins/backdrop-html-engine/backdrop-html-engine.js
+++ b/js/plugins/backdrop-html-engine/backdrop-html-engine.js
@@ -1,0 +1,231 @@
+(function (CKEditor5) {
+
+"use strict";
+
+/**
+ * A plugin that overrides the CKEditor HTML writer.
+ *
+ * Overrides the CKEditor 5 HTML writer to properly escape HTML attributes.
+ *
+ * In particular this makes it so that `<` and `>` characters are escaped when
+ * used within the data-caption attribute, allowing caption text to be linked
+ * or styled as bold, italic, etc.
+ *
+ * @see https://github.com/ckeditor/ckeditor5/issues/15293
+ * @see https://github.com/backdrop-contrib/ckeditor5/issues/68
+ */
+class BackdropHtmlEngine extends CKEditor5.core.Plugin {
+  /**
+   * @inheritdoc
+   */
+  static get pluginName() {
+    return 'BackdropHtmlEngine';
+  }
+
+  /**
+   * @inheritdoc
+   */
+  init() {
+    this.editor.data.processor.htmlWriter = new BackdropHtmlWriter();
+  }
+}
+
+// Expose the plugin to the CKEditor5 namespace.
+CKEditor5.backdropHtmlEngine = {
+  'BackdropHtmlEngine': BackdropHtmlEngine
+};
+
+/**
+ * Custom HTML writer. It creates HTML by traversing DOM nodes.
+ *
+ * It differs to CKEditor's core BasicHtmlWriter in the way it encodes entities
+ * in element attributes.
+ *
+ * @see https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_dataprocessor_basichtmlwriter-BasicHtmlWriter.html
+ */
+class BackdropHtmlWriter {
+  /**
+   * Returns an HTML string created from the document fragment.
+   *
+   * @param {Element} fragment
+   * @return {String}
+   */
+  getHtml(fragment) {
+    const builder = new BackdropHtmlBuilder();
+    builder.appendNode(fragment);
+
+    return builder.build();
+  }
+}
+
+/**
+ * HTML builder that converts document fragments into strings.
+ *
+ * Escapes ampersand characters (`&`) and angle brackets (`<` and `>`) when
+ * transforming data to HTML. This is required because filter_xss() fails to
+ * parse element attributes values containing unescaped HTML entities.
+ */
+class BackdropHtmlBuilder {
+  /**
+   * Constructs a new object.
+   */
+  constructor() {
+    this.chunks = [];
+    // @see https://html.spec.whatwg.org/multipage/syntax.html#elements-2
+    this.selfClosingTags = [
+      'area',
+      'base',
+      'br',
+      'col',
+      'embed',
+      'hr',
+      'img',
+      'input',
+      'link',
+      'meta',
+      'param',
+      'source',
+      'track',
+      'wbr',
+    ];
+  }
+
+  /**
+   * Returns the current HTML string built from document fragments.
+   *
+   * @return {string}
+   *   The HTML string built from document fragments.
+   */
+  build() {
+    return this.chunks.join('');
+  }
+
+  /**
+   * Converts a document fragment into an HTML string appended to the value.
+   *
+   * @param {Element} node
+   *   A DOM element to be appended to the value.
+   */
+  appendNode(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      this._appendText(node);
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      this._appendElement(node);
+    } else if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+      this._appendChildren(node);
+    }
+  }
+
+  /**
+   * Appends an element node to the value.
+   *
+   * @param {Element} node
+   *   A DOM element to be appended to the value.
+   */
+  _appendElement(node) {
+    const nodeName = node.nodeName.toLowerCase();
+
+    this._append('<');
+    this._append(nodeName);
+    this._appendAttributes(node);
+    this._append('>');
+    if (!this.selfClosingTags.includes(nodeName)) {
+      this._appendChildren(node);
+      this._append('</');
+      this._append(nodeName);
+      this._append('>');
+    }
+  }
+
+  /**
+   * Appends child nodes to the value.
+   *
+   * @param {Element} node
+   *  A DOM element to be appended to the value.
+   */
+  _appendChildren(node) {
+    Object.keys(node.childNodes).forEach((child) => {
+      this.appendNode(node.childNodes[child]);
+    });
+  }
+
+  /**
+   * Appends attributes to the value.
+   *
+   * @param {Element} node
+   *  A DOM element to be appended to the value.
+   */
+  _appendAttributes(node) {
+    Object.keys(node.attributes).forEach((attr) => {
+      this._append(' ');
+      this._append(node.attributes[attr].name);
+      this._append('="');
+      this._append(
+        this._escapeAttribute(node.attributes[attr].value),
+      );
+      this._append('"');
+    });
+  }
+
+  /**
+   * Appends text to the value.
+   *
+   * @param {Element} node
+   *  A DOM element to be appended to the value.
+   */
+  _appendText(node) {
+    // Repack the text into another node and extract using innerHTML. This
+    // works around text nodes not having an innerHTML property and textContent
+    // not encoding entities.
+    // entities. That's why the text is repacked into another node and extracted
+    // using innerHTML.
+    const doc = document.implementation.createHTMLDocument('');
+    const container = doc.createElement('p');
+    container.textContent = node.textContent;
+
+    this._append(container.innerHTML);
+  }
+
+  /**
+   * Appends a string to the value.
+   *
+   * @param {string} str
+   *  A string to be appended to the value.
+   */
+  _append(str) {
+    this.chunks.push(str);
+  }
+
+  /**
+   * Escapes attribute value for compatibility with Backdrop's XSS filtering.
+   *
+   * Backdrop's XSS filtering does not handle entities inside element attribute
+   * values. The XSS filtering was written based on W3C XML recommendations
+   * which constituted that the ampersand character (&) and the angle
+   * brackets (< and >) must not appear in their literal form in attribute
+   * values. This differs from the HTML living standard which permits (but
+   * discourages) unescaped angle brackets.
+   *
+   * @param {string} text
+   *  A string to be escaped.
+   *
+   * @return {string}
+   *  Escaped string.
+   *
+   * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-AttValue
+   * @see https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(single-quoted)-state
+   * @see https://github.com/whatwg/html/issues/6235
+   */
+  _escapeAttribute(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/'/g, '&apos;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\r\n/g, '&#13;')
+      .replace(/[\r\n]/g, '&#13;');
+  }
+}
+
+})(CKEditor5);

--- a/js/plugins/backdrop-image/backdrop-image.js
+++ b/js/plugins/backdrop-image/backdrop-image.js
@@ -4,6 +4,8 @@
  */
 (function (CKEditor5) {
 
+"use strict";
+
 /**
  * BackdropImage CKEditor 5 plugin.
  *
@@ -388,8 +390,7 @@ function viewCaptionToCaptionAttribute(editor) {
       }
     }
 
-    // Unbind all the view elements that were downcasted to the document
-    // fragment.
+    // Unbind all the view elements that were downcast to the document fragment.
     // eslint-disable-next-line no-restricted-syntax
     for (const child of writer
       .createRangeIn(viewDocumentFragment)

--- a/js/plugins/backdrop-link/backdrop-link.js
+++ b/js/plugins/backdrop-link/backdrop-link.js
@@ -5,6 +5,8 @@
 
 (function (Backdrop, CKEditor5) {
 
+"use strict";
+
 /**
  * The BackdropLink plugin replaces and extends the CKEditor core Link plugin.
  *

--- a/tests/ckeditor5.test
+++ b/tests/ckeditor5.test
@@ -97,10 +97,11 @@ class CKEditor5TestCase extends BackdropWebTestCase {
       'image.ImageCaption',
       'essentials.Essentials',
       'autoformat.Autoformat',
+      'htmlSupport.GeneralHtmlSupport',
+      'backdropHtmlEngine.BackdropHtmlEngine',
       'list.DocumentList',
       'blockQuote.BlockQuote',
       'backdropImage.BackdropImage',
-      'htmlSupport.GeneralHtmlSupport',
     );
     $this->assertEqual($format_settings['editorSettings']['pluginList'], $expected_plugins, 'CKEditor5 plugin list saved correctly');
 
@@ -124,9 +125,10 @@ class CKEditor5TestCase extends BackdropWebTestCase {
       'image.ImageCaption',
       'essentials.Essentials',
       'autoformat.Autoformat',
-      'backdropBasicStyles.BackdropBasicStyles',
-      'table.Table',
       'htmlSupport.GeneralHtmlSupport',
+      'backdropBasicStyles.BackdropBasicStyles',
+      'backdropHtmlEngine.BackdropHtmlEngine',
+      'table.Table',
     );
     $this->assertEqual($format_settings['editorSettings']['pluginList'], $expected_plugins, 'CKEditor5 plugin list saved correctly');
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/ckeditor5/issues/68.