### PR TITLE
Issue #109: Ensure list.DocumentList is loaded before list.DocumentListProperties.

### DIFF
--- a/ckeditor5.module
+++ b/ckeditor5.module
@@ -412,7 +412,13 @@ function ckeditor5_ckeditor5_plugins() {
         'required_html' => array('<ol>', '<li>'),
       ),
     ),
-    'plugin_dependencies' => array('list.DocumentListProperties'),
+    // Re-specify list.DocumentList as its own dependency to ensure it loads
+    // before list.DocumentListProperties, otherwise list properties will not
+    // show in the UI.
+    'plugin_dependencies' => array(
+      'list.DocumentList',
+      'list.DocumentListProperties',
+    ),
     'config' => array(
       'list' => array(
         'properties' => array(

--- a/tests/ckeditor5.test
+++ b/tests/ckeditor5.test
@@ -95,6 +95,7 @@ class CKEditor5TestCase extends BackdropWebTestCase {
       'image.ImageInsertUI',
       'image.ImageUpload',
       'image.ImageResize',
+      'list.DocumentList',
       'list.DocumentListProperties',
       'alignment.Alignment',
       'basicStyles.Italic',
@@ -106,7 +107,6 @@ class CKEditor5TestCase extends BackdropWebTestCase {
       'autoformat.Autoformat',
       'htmlSupport.GeneralHtmlSupport',
       'backdropHtmlEngine.BackdropHtmlEngine',
-      'list.DocumentList',
       'blockQuote.BlockQuote',
       'backdropImage.BackdropImage',
     );


### PR DESCRIPTION
Fixes #109 issue where list properties were not being shown in the UI.